### PR TITLE
Do not indent continuation lines

### DIFF
--- a/bashbeautify.py
+++ b/bashbeautify.py
@@ -44,6 +44,7 @@ class BeautifyBash:
     in_here_doc = False
     defer_ext_quote = False
     in_ext_quote = False
+    continued = False
     ext_quote_string = ''
     here_string = ''
     output = []
@@ -121,17 +122,22 @@ class BeautifyBash:
           tab += min(net,0)
           extab = tab + else_case + double_comma_case
           extab = max(0,extab)
-          # indent the line unless it's empty
-          if stripped_record:
-            output.append((self.tab_str * self.tab_size * extab) + stripped_record)
+          if(continued):
+            # pass on unchanged
+            output.append(record)
           else:
-            output.append('')
+            # indent the line unless it's empty
+            if stripped_record:
+              output.append((self.tab_str * self.tab_size * extab) + stripped_record)
+            else:
+              output.append('')
           tab += max(net,0)
         if(defer_ext_quote):
           in_ext_quote = True
           defer_ext_quote = False
         if(re.search(r'\bcase\b',test_record)):
           case_stack.append(0)
+      continued = record.endswith('\\')
       line += 1
     error = (tab != 0)
     if(error):

--- a/test/input/7.sh.txt
+++ b/test/input/7.sh.txt
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+f()
+{
+  # Check indent works with continuation lines
+  echo "hello" \
+       "f1"
+  echo "hello  \
+f2"
+  # Check spaces are untouched
+  echo "hello\
+   f3"
+  # Check TABs are untouched
+  echo "hello\
+	f4"
+  echo "hello\
+		f5"
+
+  ls -1 | sort |\
+    xargs wc -l |\
+    sort -n
+
+  if [ $# -eq 0 ] || \
+     [ $# -eq 1 ]; then
+  echo "hi #$#!"
+  elif [ $# -eq 2 ] || \
+       [ $# -eq 3 ] || \
+       [ $# -ge 4 ]; then
+      # Make sure to fix indent after continuation lines
+      echo "hi #$#!"
+      case "$#" in
+      0) echo zero
+      ;;
+      1|\
+      2|\
+      3)
+      echo three
+      ;;
+	*)
+	  echo whatever
+	  ;;
+      esac
+  fi
+}
+
+f "$@"

--- a/test/output/7.sh.txt
+++ b/test/output/7.sh.txt
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+f()
+{
+  # Check indent works with continuation lines
+  echo "hello" \
+       "f1"
+  echo "hello  \
+f2"
+  # Check spaces are untouched
+  echo "hello\
+   f3"
+  # Check TABs are untouched
+  echo "hello\
+	f4"
+  echo "hello\
+		f5"
+
+  ls -1 | sort |\
+    xargs wc -l |\
+    sort -n
+
+  if [ $# -eq 0 ] || \
+     [ $# -eq 1 ]; then
+    echo "hi #$#!"
+  elif [ $# -eq 2 ] || \
+       [ $# -eq 3 ] || \
+       [ $# -ge 4 ]; then
+    # Make sure to fix indent after continuation lines
+    echo "hi #$#!"
+    case "$#" in
+      0) echo zero
+        ;;
+      1|\
+      2|\
+      3)
+        echo three
+        ;;
+      *)
+        echo whatever
+        ;;
+    esac
+  fi
+}
+
+f "$@"


### PR DESCRIPTION
With various reasons scripts may use continuation lines (using `\`).
However changing indentation of the continued lines may cause
unexpected behavours.

For example, the following two cases generate different output.

```
a)
if cmd; then
    echo "continuation \
lines"
fi

b)
if cmd; then
    echo "continuation \
    lines"
fi
```

So to be safe, it would be better not to format continuation lines.
