### PR TITLE
no-merge: Workaround: tab indentation and no backup

### DIFF
--- a/bashbeautify.py
+++ b/bashbeautify.py
@@ -155,7 +155,7 @@ class BeautifyBash:
       result,error = self.beautify_string(data,path)
       if(data != result):
         # make a backup copy
-        self.write_file(path + '~',data)
+        # self.write_file(path + '~',data)
         self.write_file(path,result)
     return error
 

--- a/bashbeautify.py
+++ b/bashbeautify.py
@@ -27,8 +27,8 @@ PVERSION = '1.0'
 class BeautifyBash:
 
   def __init__(self):
-    self.tab_str = ' '
-    self.tab_size = 2
+    self.tab_str = '\t'
+    self.tab_size = 1
 
   def read_file(self,fp):
     with open(fp) as f:


### PR DESCRIPTION
This is simply a hack to use tab instead of 2 spaces as indentation, and disables the backup feature, serves as a workaround for issue #8 and #9.

Make no attempt to merge it.