### PR TITLE
Handle here-strings ("<<<word") properly

### DIFF
--- a/bashbeautify.py
+++ b/bashbeautify.py
@@ -72,6 +72,8 @@ class BeautifyBash:
       test_record = re.sub(r'(\A|\s)(#.*)','',test_record,1)
       # collapse ( ... ) or (( ... ))
       test_record = re.sub(r'\([^()]*(\([^()]*\))*[^()]*\)','',test_record)
+      # here-strings
+      test_record = re.sub(r'<<<','',test_record)
       if(in_here_doc): # pass on with no changes
         output.append(record)
         # now test for here-doc termination string

--- a/test/input/12.sh.txt
+++ b/test/input/12.sh.txt
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Test here-string ('<<<') is properly formatted
+#
+
+cat_file()
+{
+  file="$1"
+  cat - $file <<<"$*"
+   return
+}
+
+f()
+{
+  if grep -q "txt" <<< "$*"; then
+    echo "$* contains txt!"
+  fi
+  if grep -q "txt" <<< "$*"
+    then
+    echo "$* contains txt!"
+  fi
+}
+
+g()
+{
+  while read file; do
+    echo "$file"
+  done <<<$(ls -1)
+}
+
+read -r -a P <<< "${PATH}" || true
+read -r -a Q <<< "${PATH}"\
+  || true
+
+cat_file /etc/profile
+
+f "example txt"
+g

--- a/test/output/12.sh.txt
+++ b/test/output/12.sh.txt
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Test here-string ('<<<') is properly formatted
+#
+
+cat_file()
+{
+  file="$1"
+  cat - $file <<<"$*"
+  return
+}
+
+f()
+{
+  if grep -q "txt" <<< "$*"; then
+    echo "$* contains txt!"
+  fi
+  if grep -q "txt" <<< "$*"
+  then
+    echo "$* contains txt!"
+  fi
+}
+
+g()
+{
+  while read file; do
+    echo "$file"
+  done <<<$(ls -1)
+}
+
+read -r -a P <<< "${PATH}" || true
+read -r -a Q <<< "${PATH}"\
+  || true
+
+cat_file /etc/profile
+
+f "example txt"
+g


### PR DESCRIPTION
If input file uses "<<<" (here string), bashbeautify generates
"invalid expression" error.
This is now handled properly.